### PR TITLE
fix: update dockerfile version and add compose.yaml for ez build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,29 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -q && \
-    apt-get install -y -qq --no-install-recommends \
-        ca-certificates  \
-        curl \
-        ghostscript \
-        git \
-        gnuplot \
-        imagemagick \
-        make \
-        jq \
-        qpdf \
-        python3-pygments \
-        wget \
-        vim-tiny && \
-    rm -rf /var/lib/apt/lists/*
-
-WORKDIR /texlive
-
-COPY install-texlive.sh .
-COPY texlive.profile .
-
-RUN chmod +x install-texlive.sh && \
-    ./install-texlive.sh
+RUN apt update -q
+RUN apt install -y -qq --no-install-recommends \
+    ca-certificates  \
+    curl \
+    ghostscript \
+    git \
+    gnuplot \
+    imagemagick \
+    make \
+    jq \
+    qpdf \
+    python3-pygments \
+    wget \
+    vim-tiny \ 
+    perl \
+    build-essential \
+    libssl-dev \
+    texlive-full \
+    texlive-latex-extra
+RUN curl -L https://cpanmin.us | perl - App::cpanminus
+RUN cpanm YAML::Tiny
+RUN cpan File::HomeDir
 
 WORKDIR /data
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  docker-latex:
+    image: mingc/latex
+    build:
+      context: .
+      dockerfile: Dockerfile


### PR DESCRIPTION
- Adds compose.yaml to build locally easily, just run `docker compose build`
- Increases ubuntu version from 21.04 to 22.04
- Switches install from script to official `apt install texlive-full`
- Adds cpan YAML::Tiny and File::HomeDir for `latexindent` compatibility